### PR TITLE
FISH-8571 Implement Scaling Parameters

### DIFF
--- a/autoscale-groups-aws-plugin/autoscale-groups-aws-plugin-core/pom.xml
+++ b/autoscale-groups-aws-plugin/autoscale-groups-aws-plugin-core/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.extensions.autoscale.groups</groupId>
+        <artifactId>autoscale-groups-aws-plugin</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>autoscale-groups-aws-plugin-core</artifactId>
+    <description>Implementation module for AutoScale Groups AWS extension</description>
+    <packaging>glassfish-jar</packaging>
+    <name>Payara AutoScale Groups: AWS - Core</name>
+
+
+    <properties>
+        <aws.java.sdk.version>2.28.23</aws.java.sdk.version>
+        <slf4j.version>2.0.16</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>fish.payara.extensions.autoscale.groups</groupId>
+            <artifactId>autoscale-groups-api</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.server.core.common</groupId>
+            <artifactId>internal-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fish.payara.extensions.autoscale.groups</groupId>
+            <artifactId>autoscale-groups-core</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
+            <version>${aws.java.sdk.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>!software.amazon.awssdk.*,*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>software.amazon.awssdk:*</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/autoscale-groups-aws-plugin/autoscale-groups-aws-plugin-core/src/main/java/fish/payara/extensions/autoscale/groups/aws/AWSScaler.java
+++ b/autoscale-groups-aws-plugin/autoscale-groups-aws-plugin-core/src/main/java/fish/payara/extensions/autoscale/groups/aws/AWSScaler.java
@@ -1,0 +1,74 @@
+package fish.payara.extensions.autoscale.groups.aws;
+
+import fish.payara.extensions.autoscale.groups.Scaler;
+import fish.payara.extensions.autoscale.groups.ScalerFor;
+import fish.payara.extensions.autoscale.groups.ScalingGroup;
+import jakarta.inject.Inject;
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.admin.CommandRunner;
+import org.glassfish.api.admin.CommandValidationException;
+import org.jvnet.hk2.annotations.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ec2.model.InstanceType;
+
+@Service
+@ScalerFor(AWSScalingGroup.class)
+public class AWSScaler extends Scaler {
+
+    @Inject
+    private CommandRunner commandRunner;
+
+
+    @Override
+    protected void validate(int numberOfInstances, ScalingGroup scalingGroup) throws CommandValidationException {
+        super.validate(numberOfInstances, scalingGroup);
+        AWSScalingGroup awsScalingGroup = (AWSScalingGroup) scalingGroup;
+        if (awsScalingGroup.getMinInstances() < 0 ) {
+            throw new CommandValidationException("Min instances must be greater than zero");
+        }
+
+        if (awsScalingGroup.getMaxInstances() < awsScalingGroup.getMinInstances() ) {
+            throw new CommandValidationException("Max instances must be greater than Min instances");
+        }
+
+
+        Region region = Region.of(awsScalingGroup.getRegion());
+        if (!Region.regions().contains(region)) {
+            throw new CommandValidationException("Unknown AWS Region");
+        }
+        InstanceType instanceType = InstanceType.fromValue(awsScalingGroup.getInstanceType());
+        if (instanceType == null) {
+            throw new CommandValidationException("Unknown InstanceType");
+        }
+    }
+
+    /*
+     * Order of this should be:
+     * 1. Validate Configuration (instances, total instances <= max, aws info)
+     * 2. Create AWS Instance and Security Group etc
+     * 3. Create SSH Node
+     * 4. Create Instance
+     * 5. ... to be confirmed
+     */
+    @Override
+    public ActionReport scaleUp(int numberOfNewInstances, ScalingGroup scalingGroup) {
+        ActionReport actionReport = commandRunner.getActionReport("plain");
+
+        try {
+            validate(numberOfNewInstances, scalingGroup);
+        } catch (CommandValidationException commandValidationException) {
+            actionReport.setMessage("Scale up operation cancelled: an error was encountered during validation");
+            actionReport.setFailureCause(commandValidationException);
+            actionReport.setActionExitCode(ActionReport.ExitCode.FAILURE);
+            return actionReport;
+        }
+        actionReport.setMessage("validation passed");
+        actionReport.setActionExitCode(ActionReport.ExitCode.SUCCESS);
+        return actionReport;
+    }
+
+    @Override
+    public ActionReport scaleDown(int numberOfInstancesToRemove, ScalingGroup scalingGroup) {
+        return null;
+    }
+}

--- a/autoscale-groups-aws-plugin/autoscale-groups-aws-plugin-core/src/main/java/fish/payara/extensions/autoscale/groups/aws/AWSScalingGroup.java
+++ b/autoscale-groups-aws-plugin/autoscale-groups-aws-plugin-core/src/main/java/fish/payara/extensions/autoscale/groups/aws/AWSScalingGroup.java
@@ -1,0 +1,29 @@
+package fish.payara.extensions.autoscale.groups.aws;
+
+import fish.payara.extensions.autoscale.groups.ScalingGroup;
+import org.jvnet.hk2.config.Configured;
+import org.jvnet.hk2.config.Element;
+
+@Configured
+public interface AWSScalingGroup extends ScalingGroup {
+
+    @Element("region")
+    String getRegion();
+    void setRegion(String region);
+
+    @Element("instance-type")
+    String getInstanceType();
+    void setInstanceType(String instanceType);
+
+    @Element("ami-id")
+    String getAmiId();
+    void setAmiId(String amiId);
+
+    @Element("min-instances")
+    int getMinInstances();
+    void setMinInstances(int minInstances);
+
+    @Element("max-instances")
+    int getMaxInstances();
+    void setMaxInstances(int maxInstances);
+}

--- a/autoscale-groups-aws-plugin/autoscale-groups-aws-plugin-core/src/main/java/fish/payara/extensions/autoscale/groups/aws/admin/CreateAWSScalingGroupCommand.java
+++ b/autoscale-groups-aws-plugin/autoscale-groups-aws-plugin-core/src/main/java/fish/payara/extensions/autoscale/groups/aws/admin/CreateAWSScalingGroupCommand.java
@@ -1,0 +1,81 @@
+package fish.payara.extensions.autoscale.groups.aws.admin;
+
+import com.sun.enterprise.util.StringUtils;
+import fish.payara.extensions.autoscale.groups.ScalingGroups;
+import fish.payara.extensions.autoscale.groups.admin.CreateScalingGroupCommand;
+import fish.payara.extensions.autoscale.groups.aws.AWSScalingGroup;
+import org.glassfish.api.ActionReport;
+import org.glassfish.api.Param;
+import org.glassfish.api.admin.AdminCommandContext;
+import org.glassfish.api.admin.CommandValidationException;
+import org.glassfish.api.admin.ExecuteOn;
+import org.glassfish.api.admin.RestEndpoint;
+import org.glassfish.api.admin.RestEndpoints;
+import org.glassfish.api.admin.RuntimeType;
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Service;
+import org.jvnet.hk2.config.ConfigSupport;
+import org.jvnet.hk2.config.TransactionFailure;
+
+@Service(name = "create-aws-scaling-group")
+@PerLookup
+@ExecuteOn(RuntimeType.DAS)
+@RestEndpoints({
+        @RestEndpoint(configBean = ScalingGroups.class,
+                opType = RestEndpoint.OpType.POST,
+                path = "create-aws-scaling-group",
+                description = "Creates a AWS Scaling Group"
+        )
+})
+public class CreateAWSScalingGroupCommand extends CreateScalingGroupCommand {
+
+
+    @Param(name = "region")
+    private String region;
+
+    @Param(name = "instance-type")
+    private String instanceType;
+
+    @Param(name = "ami-id")
+    private String amiId;
+
+    @Param(name = "min-instances")
+    private int minInstances;
+
+    @Param(name = "max-instances")
+    private int maxInstances;
+    
+    @Override
+    public void execute(AdminCommandContext adminCommandContext) {
+        try {
+            validateParams();
+        } catch (CommandValidationException commandValidationException) {
+            adminCommandContext.getActionReport().setFailureCause(commandValidationException);
+            adminCommandContext.getActionReport().setActionExitCode(ActionReport.ExitCode.FAILURE);
+            return;
+        }
+
+        try {
+            ConfigSupport.apply(scalingGroupsProxy -> {
+                AWSScalingGroup awsScalingGroupProxy = scalingGroupsProxy.createChild(AWSScalingGroup.class);
+                awsScalingGroupProxy.setName(name);
+                awsScalingGroupProxy.setDeploymentGroupRef(deploymentGroupRef);
+
+                if (StringUtils.ok(configRef)) {
+                    awsScalingGroupProxy.setConfigRef(configRef);
+                }
+                awsScalingGroupProxy.setRegion(region);
+                awsScalingGroupProxy.setInstanceType(instanceType);
+                awsScalingGroupProxy.setAmiId(amiId);
+                awsScalingGroupProxy.setMinInstances(minInstances);
+                awsScalingGroupProxy.setMaxInstances(maxInstances);
+
+                scalingGroupsProxy.getScalingGroups().add(awsScalingGroupProxy);
+                return scalingGroupsProxy;
+            }, scalingGroups);
+        } catch (TransactionFailure transactionFailure) {
+            adminCommandContext.getActionReport().setActionExitCode(ActionReport.ExitCode.FAILURE);
+            adminCommandContext.getActionReport().setFailureCause(transactionFailure);
+        }
+    }
+}

--- a/autoscale-groups-aws-plugin/pom.xml
+++ b/autoscale-groups-aws-plugin/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fish.payara.extensions.autoscale.groups</groupId>
+        <artifactId>autoscale-groups-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+
+    <artifactId>autoscale-groups-aws-plugin</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Payara AutoScale Groups: AWS</name>
+
+    <modules>
+        <module>autoscale-groups-aws-plugin-core</module>
+    </modules>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <module>autoscale-groups-nodes-plugin</module>
         <module>autoscale-groups-core</module>
         <module>autoscale-groups-console</module>
+        <module>autoscale-groups-aws-plugin</module>
     </modules>
 
     <pluginRepositories>


### PR DESCRIPTION
Shade AWS SDK into plugin and add parameters and validation - was going to validate AWS login but there is no feasible way to do this to ensure that EC2 creation is possible due to design.

Will require validation of AWS credentials when creating EC2 instance. 

Steps to test
1. Create deployment group
2. Create 'aws-scaling-group' e.g. `./asadmin create-aws-scaling-group --region eu-west-1 --instance-type t2.large --ami-id test --min-instances 1 --max-instances 3 --deploymentgroup dg1 --config server-config`
3. Run `scale-up`  command